### PR TITLE
GEOMESA-1740 modify denormalize with fully characterized impl.

### DIFF
--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/NormalizedDimension.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/NormalizedDimension.scala
@@ -17,7 +17,13 @@ trait NormalizedDimension {
     require(x >= min && x <= max, s"Value out of bounds ([$min $max]): $x")
     math.ceil((x - min) / (max - min) * precision).toInt
   }
-  def denormalize(x: Double): Double = (x / (precision + 0.5d)) * (max - min) + min
+
+  def denormalize(x: Int): Double = {
+    if (x == 0)
+      min
+    else
+      (x - 0.5d) * (max - min) / precision + min
+  }
 }
 
 case class NormalizedLat(precision: Long) extends NormalizedDimension {

--- a/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/NormalizedDimensionTest.scala
+++ b/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/NormalizedDimensionTest.scala
@@ -15,20 +15,53 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class NormalizedDimensionTest extends Specification {
 
-  val prec: Long = math.pow(2, 31).toLong - 1
-  val NormLat = NormalizedLat(prec)
-  val NormLon = NormalizedLon(prec)
+  val precision: Long = (1L << 31) - 1
+  val NormLat = NormalizedLat(precision)
+  val NormLon = NormalizedLon(precision)
 
   "NormalizedDimension" should {
 
-    "Round-trip normalize 0" >> {
+    "Round-trip normalize minimum" >> {
       NormLat.normalize(NormLat.denormalize(0)) mustEqual 0
       NormLon.normalize(NormLon.denormalize(0)) mustEqual 0
     }
 
-    "Round-trip normalize precision" >> {
-      NormLat.normalize(NormLat.denormalize(prec)) mustEqual prec
-      NormLon.normalize(NormLon.denormalize(prec)) mustEqual prec
+    "Round-trip normalize maximum" >> {
+      NormLat.normalize(NormLat.denormalize(precision.toInt)) mustEqual precision
+      NormLon.normalize(NormLon.denormalize(precision.toInt)) mustEqual precision
     }
+
+    "Normalize mininimum" >> {
+      NormLat.normalize(NormLat.min) mustEqual 0
+      NormLon.normalize(NormLon.min) mustEqual 0
+    }
+
+    "Normalize maximum" >> {
+      NormLat.normalize(NormLat.max) mustEqual precision
+      NormLon.normalize(NormLon.max) mustEqual precision
+    }
+
+    "Denormalize 0 to min (special case)" >> {
+      // this is to mirror use of Math.ceil in normalize
+      NormLat.denormalize(0) mustEqual NormLat.min
+      NormLon.denormalize(0) mustEqual NormLon.min
+    }
+
+    "Denormalize [1,precision] to bin middle" >> {
+      // for any index/bin in range [1,precision] denormalize will return value in middle
+      //   of range of coordinates that could result in index/bin from normalize call
+      val latExtent = NormLat.max - NormLat.min
+      val latWidth = latExtent / precision
+      val epsilon = 1d / precision
+
+      NormLat.denormalize(1) must beCloseTo(NormLat.min + latWidth / 2d, epsilon)
+      NormLat.denormalize(precision.toInt) must beCloseTo(NormLat.max - latWidth / 2d, epsilon)
+
+      val lonExtent = NormLon.max - NormLon.min
+      val lonWidth = lonExtent / precision
+      NormLon.denormalize(1) must beCloseTo(NormLon.min + lonWidth / 2d, epsilon)
+      NormLon.denormalize(precision.toInt) must beCloseTo(NormLon.max - lonWidth / 2d, epsilon)
+    }
+
   }
 }


### PR DESCRIPTION
I went through the denorm method and fully mapped to norm to make sure every thing was understood and characterized in unit tests.  The denorm method will now return a value from the middle of the range of all possible inputs that that might results in the given index (x).  This should be numerically stable given increased precision.  