### PR TITLE
GEOMESA-1769 remove use of case class with DescriptiveStats

### DIFF
--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/DescriptiveStats.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/DescriptiveStats.scala
@@ -16,7 +16,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.ListMap
 import scala.Array._
 
-case class DescriptiveStats(val attributes: Seq[Int]) extends Stat with Serializable {
+class DescriptiveStats(val attributes: Seq[Int]) extends Stat with Serializable {
 
   override type S = DescriptiveStats
 
@@ -318,7 +318,7 @@ case class DescriptiveStats(val attributes: Seq[Int]) extends Stat with Serializ
   }
 
   override def newcopy: Stat = {
-    val newstat = this.copy()
+    val newstat = new DescriptiveStats(attributes)
     newstat.copyFrom(this)
     newstat
   }


### PR DESCRIPTION
Might want to reconsider `case class` use with other Stats classes

Signed-off-by: Tom Kunicki <tom.kunicki@ccri.com>